### PR TITLE
Don't use root user for qBittorrent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config/
 downloads/
 build.cmd
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Ok lets install everything
 RUN apk add --no-cache -t .build-deps autoconf automake build-base cmake curl git libtool linux-headers perl pkgconf python3-dev re2c tar unzip icu-dev libexecinfo-dev openssl-dev qt5-qtbase-dev qt5-qttools-dev zlib-dev qt5-qtsvg-dev && \
-	apk add --no-cache ca-certificates libexecinfo libressl qt5-qtbase iptables openvpn ack bind-tools python3 && \
+	apk add --no-cache ca-certificates libexecinfo libressl qt5-qtbase iptables openvpn ack bind-tools python3 doas tzdata && \
 	if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi && \
   curl -sNLk --retry 5 https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz | tar xzC /tmp && \
   curl -sSL --retry 5 https://github.com/ninja-build/ninja/archive/refs/tags/v1.10.2.tar.gz | tar xzC /tmp && \
@@ -64,7 +64,16 @@ RUN apk add --no-cache -t .build-deps autoconf automake build-base cmake curl gi
 
 COPY ./entrypoint.sh ./qBittorrent.conf /
 
+# Add qBittorrent User
+RUN adduser \
+        -D \
+        -H \
+        -s /sbin/nologin \
+        -u 1000 \
+        qbtUser && \
+    echo "permit nopass :root" >> "/etc/doas.d/doas.conf"
+
 RUN chmod 500 /entrypoint.sh
 
 # Start point for docker
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT "/entrypoint.sh"

--- a/README.md
+++ b/README.md
@@ -79,13 +79,16 @@ try [http://checkmyip.torrentprivacy.com/](http://checkmyip.torrentprivacy.com/)
 
 ## Environment variables
 
-| Environment variable | Default | Description |
-| --- | --- | --- |
-| `REGION` | `Netherlands` | One of the [PIA regions](https://www.privateinternetaccess.com/pages/network/) |
-| `USER` | | Your PIA username |
-| `PASSWORD` | | Your PIA password |
-| `WEBUI_PORT` | `8888` | `1024` to `65535` internal port for HTTP proxy |
-! `DNS_SERVERS` | `209.222.18.222,209.222.18.218,103.196.38.38,103.196.38.39` | DNS servers to use, comma separated
+| Environment variable | Default | Description                                                                    |
+|----------------------| --- |--------------------------------------------------------------------------------|
+| `REGION`             | `Netherlands` | One of the [PIA regions](https://www.privateinternetaccess.com/pages/network/) |
+| `USER`               | | Your PIA username                                                              |
+| `PASSWORD`           | | Your PIA password                                                              |
+| `WEBUI_PORT`         | `8888` | `1024` to `65535` internal port for HTTP proxy                                 |
+| `DNS_SERVERS`        | `209.222.18.222,209.222.18.218,103.196.38.38,103.196.38.39` | DNS servers to use, comma separated                                            
+| `PUID`               | | The UserID                                                                     |
+| `PGID`               | | The GroupID                                                                    |
+| `TZ`                 | | The Timzeone                                                                   |
 
 PIA DNS Servers 209.222.18.222 and 209.222.18.218
 Handshake DNS Servers 103.196.38.38 and 103.196.38.39


### PR DESCRIPTION
I'm actually using your image and it's amazing! Here are some improvements to make it work with the *-arr stack hardlinks :)

Additions:
- Ability to set PUID, PGID, UMASK and TZ
- qBittorrent is not run as root user anymore making download file permissions not root (Which allows for hardlinking from the *-arr stack)
- README update