### PR TITLE
Always unset USER & PASSWORD

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,11 +114,11 @@ else
   chmod 400 /auth.conf
   exitOnError $?
   printf "DONE\n"
-  printf "[INFO] Clearing environment variables USER and PASSWORD..."
-  unset -v USER
-  unset -v PASSWORD
-  printf "DONE\n"
 fi
+printf "[INFO] Clearing environment variables USER and PASSWORD..."
+unset -v USER
+unset -v PASSWORD
+printf "DONE\n"
 
 ############################################
 # CHECK FOR TUN DEVICE


### PR DESCRIPTION
USER and PASSWORD env variables should always be unset, whether /auth.conf exists or not