### PR TITLE
Fix port forwarding and healthcheck permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN adduser \
         qbtUser && \
     echo "permit nopass :root" >> "/etc/doas.d/doas.conf"
 
-RUN chmod 500 /entrypoint.sh
+RUN chmod 500 /entrypoint.sh /healthcheck.sh
 
 # Start point for docker
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -75,7 +75,7 @@ RUN adduser \
         qbtUser && \
     echo "permit nopass :root" >> "/etc/doas.d/doas.conf"
 
-RUN chmod 500 /entrypoint.sh
+RUN chmod 500 /entrypoint.sh /healthcheck.sh
 
 # Start point for docker
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -68,7 +68,7 @@ RUN useradd \
     echo "permit nopass :root" >> "/etc/doas.conf"
 
 
-RUN chmod 500 /entrypoint.sh
+RUN chmod 500 /entrypoint.sh /healthcheck.sh
 
 # Start point for docker
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -597,7 +597,7 @@ if "$PORT_FORWARDING"; then
     printf " * Got PIA gateway $PIA_GATEWAY\n"
   fi
 
-  piasif=$(curl -k -s "$(sed '1!d' /auth.conf):$(sed '2!d' /auth.conf))" "https://$PIA_GATEWAY:19999/getSignature?token=$piatoken")
+  piasif=$(curl -k -s "https://$PIA_GATEWAY:19999/getSignature?token=$piatoken")
   if [ -z "$piasif" ]; then
     printf "[ERROR] Unable to start port forwarding. Is port forwarding avalable in your chosen region?\n"
     printf "https://github.com/j4ym0/pia-qbittorrent-docker/wiki/PIA-Servers \n"


### PR DESCRIPTION
## Summary

- **Port forwarding fix**: The `getSignature` curl call in `entrypoint.sh:600` had a bogus credentials argument and stray `)` that caused it to fail. The PIA token already contains auth from the previous API call, so credentials aren't needed again for the signature request.
- **Healthcheck fix**: `healthcheck.sh` was never marked executable (`chmod 500`) in any of the three Dockerfiles, causing containers to report as unhealthy with "Permission denied".

## Test plan

- [x] Verified port forwarding works end-to-end (token → signature → payload → bind) after the curl fix
- [x] Verified healthcheck passes and container reports healthy after chmod fix
- Tested on Alpine-based image running on TrueNAS SCALE