### PR TITLE
configurable-download-dir: Make download directory configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,8 @@ ENV PIA_USERNAME= \
     WEBUI_PORT=8888 \
     DNS_SERVERS=9.9.9.9,149.112.112.112 \
     UID=700 \
-    GID=700
-
-# Download Folder
-VOLUME /downloads
+    GID=700 \
+    DOWNLOAD_DIR=
 
 # qBittorrent Config Folder
 VOLUME /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,10 @@ ENV PIA_USERNAME= \
     WEBUI_PORT=8888 \
     DNS_SERVERS=9.9.9.9,149.112.112.112 \
     UID=700 \
-    GID=700 \
-    DOWNLOAD_DIR=
+    GID=700 
+
+# Default Download Folder
+VOLUME /downloads
 
 # qBittorrent Config Folder
 VOLUME /config

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -10,10 +10,8 @@ ENV PIA_USERNAME= \
     WEBUI_PORT=8888 \
     DNS_SERVERS=9.9.9.9,149.112.112.112 \
     UID=700 \
-    GID=700
-
-# Download Folder
-VOLUME /downloads
+    GID=700 \
+    DOWNLOAD_DIR=
 
 # qBittorrent Config Folder
 VOLUME /config

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -10,8 +10,10 @@ ENV PIA_USERNAME= \
     WEBUI_PORT=8888 \
     DNS_SERVERS=9.9.9.9,149.112.112.112 \
     UID=700 \
-    GID=700 \
-    DOWNLOAD_DIR=
+    GID=700 
+
+# Default Download Folder
+VOLUME /downloads
 
 # qBittorrent Config Folder
 VOLUME /config

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -10,10 +10,8 @@ ENV PIA_USERNAME= \
     WEBUI_PORT=8888 \
     DNS_SERVERS=9.9.9.9,149.112.112.112 \
     UID=700 \
-    GID=700
-
-# Download Folder
-VOLUME /downloads
+    GID=700 \
+    DOWNLOAD_DIR=
 
 # qBittorrent Config Folder
 VOLUME /config

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -10,8 +10,10 @@ ENV PIA_USERNAME= \
     WEBUI_PORT=8888 \
     DNS_SERVERS=9.9.9.9,149.112.112.112 \
     UID=700 \
-    GID=700 \
-    DOWNLOAD_DIR=
+    GID=700 
+
+# Default Download Folder
+VOLUME /downloads
 
 # qBittorrent Config Folder
 VOLUME /config

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@
 - Lightweight 
 - Self contained qBittorrent
 - Exposed webUI
-- Config volume; download path configurable via `DOWNLOAD_DIR`
+- Config and downloads volume
+- Download path configurable via `DOWNLOAD_DIR`
 - The *iptables* firewall allows traffic only with needed PIA servers (IP addresses, port, protocol) combinations
 - OpenVPN reconnects automatically on failure
 - Port forwarding for seeding
@@ -65,14 +66,14 @@
     Basic Launch
     ```bash
     docker run -d --init --name=pia --restart unless-stopped --cap-add=NET_ADMIN \
-    -v /My/Downloads/Folder/:/downloads -e DOWNLOAD_DIR=/downloads -p 8888:8888 \
+    -v /My/Downloads/Folder/:/downloads -p 8888:8888 \
     -e PIA_REGION=netherlands -e PIA_USERNAME=xxxxxxx -e PIA_PASSWORD=xxxxxxxx \
     j4ym0/pia-qbittorrent
     ```  
     Using [/auth.conf file](#auth.conf File)
     ```bash
     docker run -d --init --name=pia --restart unless-stopped --cap-add=NET_ADMIN \
-    -v /My/Downloads/Folder/:/downloads -e DOWNLOAD_DIR=/downloads \
+    -v /My/Downloads/Folder/:/downloads \
     -v /qBittorrent/config/:/config \
     -v /My/auth.conf:/auth.conf -p 8888:8888 -e PIA_REGION=netherlands \
     j4ym0/pia-qbittorrent
@@ -80,7 +81,7 @@
     Advanced Launch
     ```bash
     docker run -d --init --name=pia --restart unless-stopped --cap-add=NET_ADMIN \
-    -v /My/Downloads/Folder/:/downloads -e DOWNLOAD_DIR=/downloads \
+    -v /My/shared-download-folder/:/shared-download-folder -e DOWNLOAD_DIR=/shared-download-folder \
     -v /qBittorrent/config/:/config \
     -p 8888:8888 -e PIA_REGION=netherlands -e PIA_USERNAME=xxxxxxx -e PIA_PASSWORD=xxxxxxxx \
     -e UID=3 -e GID=3 -e TZ=Etc/UTC -e PORT_FORWARDING=true -e VPN_CLIENT=wireguard \
@@ -119,9 +120,9 @@ try [WhatisMyIP.net torrent-ip-checker]([http://checkmyip.torrentprivacy.com/](h
 | `UID`                | 700               | The UserID                                                                                    |
 | `GID`                | 700               | The GroupID                                                                                   |
 | `TZ`                 |                   | The Timezone                                                                                      |
-| `HOSTHEADERVALIDATION`|                   | Set to `false` if having trouble accessing the WebUI with unauthorized                           |
+| `HOSTHEADERVALIDATION`|                  | Set to `false` if having trouble accessing the WebUI with unauthorized                           |
 | `CSRFPROTECTION`     |                   | Set to `false` if having trouble accessing the WebUI with unauthorized                            |
-| `DOWNLOAD_DIR`       | `/downloads`      | Mount your download volume at any path and set this to that path. qBittorrent's save path and temp path are updated on every start; if the value already matches nothing is changed |
+| `DOWNLOAD_DIR`       |                   | Set this to your download folder location. qBittorrent's save and temp paths will update automatically on each start. Leave empty to keep your current settings (default: /downloads) |
 
 Port forwarding port will be added to qBittorrent settings on startup. A port can last for up to 2 months.  
 To get the user id, run `id -u USER`  
@@ -170,7 +171,7 @@ Pa$$W<>rd
 Launch
 ```bash
 docker run -d --init --name=pia --restart unless-stopped --cap-add=NET_ADMIN
--v /My/Downloads/Folder/:/downloads -e DOWNLOAD_DIR=/downloads \
+-v /My/Downloads/Folder/:/downloads \
 -v /qBittorrent/config/:/config \
 -v /My/auth.conf:/auth.conf -p 8888:8888 -e PIA_REGION="Netherlands" \
 j4ym0/pia-qbittorrent
@@ -276,6 +277,7 @@ Have a look at the [Wiki Page](https://github.com/j4ym0/pia-qbittorrent-docker/w
 ## TODOs
 
 - More DNS leak testing
+- Edit config from environment vars
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 - Lightweight 
 - Self contained qBittorrent
 - Exposed webUI
-- Downloads & config Volumes
+- Config volume; download path configurable via `DOWNLOAD_DIR`
 - The *iptables* firewall allows traffic only with needed PIA servers (IP addresses, port, protocol) combinations
 - OpenVPN reconnects automatically on failure
 - Port forwarding for seeding
@@ -65,21 +65,23 @@
     Basic Launch
     ```bash
     docker run -d --init --name=pia --restart unless-stopped --cap-add=NET_ADMIN \
-    -v /My/Downloads/Folder/:/downloads -p 8888:8888 \
+    -v /My/Downloads/Folder/:/downloads -e DOWNLOAD_DIR=/downloads -p 8888:8888 \
     -e PIA_REGION=netherlands -e PIA_USERNAME=xxxxxxx -e PIA_PASSWORD=xxxxxxxx \
     j4ym0/pia-qbittorrent
     ```  
     Using [/auth.conf file](#auth.conf File)
     ```bash
     docker run -d --init --name=pia --restart unless-stopped --cap-add=NET_ADMIN \
-    -v /My/Downloads/Folder/:/downloads -v /qBittorrent/config/:/config \
+    -v /My/Downloads/Folder/:/downloads -e DOWNLOAD_DIR=/downloads \
+    -v /qBittorrent/config/:/config \
     -v /My/auth.conf:/auth.conf -p 8888:8888 -e PIA_REGION=netherlands \
     j4ym0/pia-qbittorrent
     ```
     Advanced Launch
     ```bash
     docker run -d --init --name=pia --restart unless-stopped --cap-add=NET_ADMIN \
-    -v /My/Downloads/Folder/:/downloads -v /qBittorrent/config/:/config \
+    -v /My/Downloads/Folder/:/downloads -e DOWNLOAD_DIR=/downloads \
+    -v /qBittorrent/config/:/config \
     -p 8888:8888 -e PIA_REGION=netherlands -e PIA_USERNAME=xxxxxxx -e PIA_PASSWORD=xxxxxxxx \
     -e UID=3 -e GID=3 -e TZ=Etc/UTC -e PORT_FORWARDING=true -e VPN_CLIENT=wireguard \
     j4ym0/pia-qbittorrent
@@ -101,24 +103,25 @@ try [WhatisMyIP.net torrent-ip-checker]([http://checkmyip.torrentprivacy.com/](h
 
 ## Environment variables
 
-| Environment variable | Default | Description                                                                               |
-|----------------------| --- |-----------------------------------------------------------------------------------------------|
-| `PIA_REGION`         | `netherlands` | List of [PIA Servers](https://github.com/j4ym0/pia-qbittorrent-docker/wiki/PIA-Servers)  |
-| `PIA_USERNAME`       | | Your PIA username ([consider using /auth.conf file](#auth.conf-File))                             |
-| `PIA_PASSWORD`       | | Your PIA password ([consider using /auth.conf file](#auth.conf-File))                             |
-| `VPN_CLIENT`         | `openvpn` | Switch between `openvpn` and `wireguard` VPN client                                     |
-| `VPN_LOG_MAX_ITERATIONS`| 3 | Max number of VPN Client logs to keep to debug vpn connection. Saved in /log. Set to `0` for no logs |
-| `PORT_FORWARDING`    | `false` | Set to `true` if you want to enable port forwarding from PIA, This helps with uploading   |
-| `WEBUI_PORT`         | `8888` | `1024` to `65535` internal port for HTTP UI                                             |
-| `WEBUI_INTERFACES`   | | `eth0` or `eth0,eth1` the interface the WebUI can be accessed through, useful if multiple networks are attached to the container. The default is the interface used for internet access if unset |
-| `ALLOW_LOCAL_SUBNET_TRAFFIC`| `false` | Set it `true` to allow connections from your local network to the container, WebUI port is still when `false` |
-| `LEGACY_IPTABLES`    | `false` | Set to `true` if nft protocol not supported or you want to use iptables_legacy            |
+| Environment variable | Default           | Description                                                                               |
+|----------------------|-------------------|-----------------------------------------------------------------------------------------------|
+| `PIA_REGION`         | `netherlands`     | List of [PIA Servers](https://github.com/j4ym0/pia-qbittorrent-docker/wiki/PIA-Servers)  |
+| `PIA_USERNAME`       |                   | Your PIA username ([consider using /auth.conf file](#auth.conf-File))                             |
+| `PIA_PASSWORD`       |                   | Your PIA password ([consider using /auth.conf file](#auth.conf-File))                             |
+| `VPN_CLIENT`         | `openvpn`         | Switch between `openvpn` and `wireguard` VPN client                                     |
+| `VPN_LOG_MAX_ITERATIONS`| 3                 | Max number of VPN Client logs to keep to debug vpn connection. Saved in /log. Set to `0` for no logs |
+| `PORT_FORWARDING`    | `false`           | Set to `true` if you want to enable port forwarding from PIA, This helps with uploading   |
+| `WEBUI_PORT`         | `8888`            | `1024` to `65535` internal port for HTTP UI                                             |
+| `WEBUI_INTERFACES`   |                   | `eth0` or `eth0,eth1` the interface the WebUI can be accessed through, useful if multiple networks are attached to the container. The default is the interface used for internet access if unset |
+| `ALLOW_LOCAL_SUBNET_TRAFFIC`| `false`           | Set it `true` to allow connections from your local network to the container, WebUI port is still when `false` |
+| `LEGACY_IPTABLES`    | `false`           | Set to `true` if nft protocol not supported or you want to use iptables_legacy            |
 | `DNS_SERVERS`        | `1.1.1.1,1.0.0.1` | DNS servers to use, comma separated [see list](#DNS Servers)          |
-| `UID`                | 700 | The UserID                                                                                    |
-| `GID`                | 700 | The GroupID                                                                                   |
-| `TZ`                 | | The Timezone                                                                                      |
-| `HOSTHEADERVALIDATION`| | Set to `false` if having trouble accessing the WebUI with unauthorized                           |
-| `CSRFPROTECTION`     | | Set to `false` if having trouble accessing the WebUI with unauthorized                            |
+| `UID`                | 700               | The UserID                                                                                    |
+| `GID`                | 700               | The GroupID                                                                                   |
+| `TZ`                 |                   | The Timezone                                                                                      |
+| `HOSTHEADERVALIDATION`|                   | Set to `false` if having trouble accessing the WebUI with unauthorized                           |
+| `CSRFPROTECTION`     |                   | Set to `false` if having trouble accessing the WebUI with unauthorized                            |
+| `DOWNLOAD_DIR`       | `/downloads`      | Mount your download volume at any path and set this to that path. qBittorrent's save path and temp path are updated on every start; if the value already matches nothing is changed |
 
 Port forwarding port will be added to qBittorrent settings on startup. A port can last for up to 2 months.  
 To get the user id, run `id -u USER`  
@@ -167,7 +170,8 @@ Pa$$W<>rd
 Launch
 ```bash
 docker run -d --init --name=pia --restart unless-stopped --cap-add=NET_ADMIN
--v /My/Downloads/Folder/:/downloads -v /qBittorrent/config/:/config \
+-v /My/Downloads/Folder/:/downloads -e DOWNLOAD_DIR=/downloads \
+-v /qBittorrent/config/:/config \
 -v /My/auth.conf:/auth.conf -p 8888:8888 -e PIA_REGION="Netherlands" \
 j4ym0/pia-qbittorrent
 ```
@@ -272,7 +276,6 @@ Have a look at the [Wiki Page](https://github.com/j4ym0/pia-qbittorrent-docker/w
 ## TODOs
 
 - More DNS leak testing
-- Edit config from environment vars
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,11 @@ services:
             - PORT_FORWARDING=true
             - VPN_CLIENT=wireguard
             - WEBUI_PORT=8888
-            - DOWNLOAD_DIR=
+#            - DOWNLOAD_DIR=
         volumes:
 #            - ./auth.conf:/auth.conf
             - ./config:/config
-#            - ./downloads:/downloads
+            - ./downloads:/downloads
         ports:
             - "8888:8888"
         restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,11 @@ services:
             - PORT_FORWARDING=true
             - VPN_CLIENT=wireguard
             - WEBUI_PORT=8888
+            - DOWNLOAD_DIR=
         volumes:
 #            - ./auth.conf:/auth.conf
             - ./config:/config
-            - ./downloads:/downloads
+#            - ./downloads:/downloads
         ports:
             - "8888:8888"
         restart: unless-stopped

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -729,15 +729,23 @@ if [ -n "$DOWNLOAD_DIR" ]; then
   # Strip any trailing slash so comparisons and appends are consistent
   DOWNLOAD_DIR="${DOWNLOAD_DIR%/}"
   QBT_CONF="/config/qBittorrent/config/qBittorrent.conf"
-  CURRENT_SAVE=$(grep -F 'Downloads\SavePath=' "$QBT_CONF" | cut -d= -f2-)
-  CURRENT_TEMP=$(grep -F 'Downloads\TempPath=' "$QBT_CONF" | cut -d= -f2-)
+  CURRENT_SAVE=$(grep -F 'Session\DefaultSavePath=' "$QBT_CONF" | cut -d= -f2-)
+  CURRENT_TEMP=$(grep -F 'Session\TempPath=' "$QBT_CONF" | cut -d= -f2-)
+
+  # Create the download directory if it doesn't exist
+  if [ ! -d "$DOWNLOAD_DIR" ]; then
+    printf " * Creating DOWNLOAD_DIR - $DOWNLOAD_DIR\n"
+    mkdir -p "$DOWNLOAD_DIR"
+  fi
+
+  # Update the qbittorrent config
   if [ "$CURRENT_SAVE" != "$DOWNLOAD_DIR/" ]; then
-    printf " * Updating Downloads\\\\SavePath to $DOWNLOAD_DIR/\n"
-    sed -i "s|Downloads\\\SavePath=.*|Downloads\\\SavePath=$DOWNLOAD_DIR/|" "$QBT_CONF"
+    printf " * Updating Session\\\\DefaultSavePath to $DOWNLOAD_DIR/\n"
+    sed -i "s|Session\\\DefaultSavePath=.*|Session\\\DefaultSavePath=$DOWNLOAD_DIR/|" "$QBT_CONF"
   fi
   if [ "$CURRENT_TEMP" != "$DOWNLOAD_DIR/temp/" ]; then
-    printf " * Updating Downloads\\\\TempPath to $DOWNLOAD_DIR/temp/\n"
-    sed -i "s|Downloads\\\TempPath=.*|Downloads\\\TempPath=$DOWNLOAD_DIR/temp/|" "$QBT_CONF"
+    printf " * Updating Session\\\\TempPath to $DOWNLOAD_DIR/temp/\n"
+    sed -i "s|Session\\\TempPath=.*|Session\\\TempPath=$DOWNLOAD_DIR/temp/|" "$QBT_CONF"
   fi
 fi
 
@@ -751,16 +759,17 @@ if [ -n "$qbtUser_GID" ]; then
   sed -i "s|^qbtUser:x:[0-9]*:|qbtUser:x:$qbtUser_GID:|g" /etc/group
 fi
 
-# Set ownership of config folder
+# Set ownership and permissions of config folder
 chown qbtUser:qbtUser -R /config
-
-# Set permissions of config folder
 chmod 700 -R /config
 
-# Set ownership and permissions of the download directory if configured
+# Set ownership and permissions of the download directory
 if [ -n "$DOWNLOAD_DIR" ] && [ -d "$DOWNLOAD_DIR" ]; then
   chown qbtUser:qbtUser "$DOWNLOAD_DIR"
   chmod 755 "$DOWNLOAD_DIR"
+else
+  chown qbtUser:qbtUser /downloads
+  chmod 755 /downloads
 fi
 
 # Wait until vpn is up

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -725,6 +725,22 @@ if [ "${CSRFPROTECTION}" = "true" ] || [ "${CSRFPROTECTION}" = "false" ]; then
   sed -i "s/WebUI\\\CSRFProtection=\(true\|false\)/WebUI\\\CSRFProtection=$CSRFPROTECTION/g" /config/qBittorrent/config/qBittorrent.conf
 fi
 
+if [ -n "$DOWNLOAD_DIR" ]; then
+  # Strip any trailing slash so comparisons and appends are consistent
+  DOWNLOAD_DIR="${DOWNLOAD_DIR%/}"
+  QBT_CONF="/config/qBittorrent/config/qBittorrent.conf"
+  CURRENT_SAVE=$(grep -F 'Downloads\SavePath=' "$QBT_CONF" | cut -d= -f2-)
+  CURRENT_TEMP=$(grep -F 'Downloads\TempPath=' "$QBT_CONF" | cut -d= -f2-)
+  if [ "$CURRENT_SAVE" != "$DOWNLOAD_DIR/" ]; then
+    printf " * Updating Downloads\\\\SavePath to $DOWNLOAD_DIR/\n"
+    sed -i "s|Downloads\\\SavePath=.*|Downloads\\\SavePath=$DOWNLOAD_DIR/|" "$QBT_CONF"
+  fi
+  if [ "$CURRENT_TEMP" != "$DOWNLOAD_DIR/temp/" ]; then
+    printf " * Updating Downloads\\\\TempPath to $DOWNLOAD_DIR/temp/\n"
+    sed -i "s|Downloads\\\TempPath=.*|Downloads\\\TempPath=$DOWNLOAD_DIR/temp/|" "$QBT_CONF"
+  fi
+fi
+
 # Set user and group id
 if [ -n "$qbtUser_UID" ]; then
   sed -i "s|^qbtUser:x:[0-9]*:|qbtUser:x:$qbtUser_UID:|g" /etc/passwd
@@ -735,13 +751,17 @@ if [ -n "$qbtUser_GID" ]; then
   sed -i "s|^qbtUser:x:[0-9]*:|qbtUser:x:$qbtUser_GID:|g" /etc/group
 fi
 
-# Set ownership of folders, but don't set ownership of existing files in downloads
-chown qbtUser:qbtUser /downloads
+# Set ownership of config folder
 chown qbtUser:qbtUser -R /config
 
-# Set permissions of folders, but don't set permissions of existing files in downloads
-chmod 755 /downloads
+# Set permissions of config folder
 chmod 700 -R /config
+
+# Set ownership and permissions of the download directory if configured
+if [ -n "$DOWNLOAD_DIR" ] && [ -d "$DOWNLOAD_DIR" ]; then
+  chown qbtUser:qbtUser "$DOWNLOAD_DIR"
+  chmod 755 "$DOWNLOAD_DIR"
+fi
 
 # Wait until vpn is up
 printf "[INFO] Waiting for VPN to connect"


### PR DESCRIPTION
Make downloads directory configurable through env vars while keeping the default `/downloads` without the env var present. 