### PR TITLE
Adding a New EnvVar to handle custom, additional WebUI Ports for other Docker Containers sharing the PIA Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ try [WhatisMyIP.net torrent-ip-checker]([http://checkmyip.torrentprivacy.com/](h
 | `PORT_FORWARDING`    | `false`           | Set to `true` if you want to enable port forwarding from PIA, This helps with uploading   |
 | `WEBUI_PORT`         | `8888`            | `1024` to `65535` internal port for HTTP UI                                             |
 | `WEBUI_INTERFACES`   |                   | `eth0` or `eth0,eth1` the interface the WebUI can be accessed through, useful if multiple networks are attached to the container. The default is the interface used for internet access if unset |
-| `ADDITIONAL_OPEN_PORTS` |                | A comma-separated list of additional ports to open on the local `WEBUI_INTERFACES` (e.g. `1234,5678,9012`). Useful for additional containers with WebUIs that need to share the PIA network you're seeding from (e.g. Prowlarr, Mousehole). |
+| `OPEN_ADDITIONAL_LOCAL_PORTS` |          | A comma-separated list of additional ports to open on the local `WEBUI_INTERFACES` (e.g. `1234,5678,9012`). Useful for additional containers with WebUIs that need to share the PIA network (e.g. Prowlarr, Mousehole). |
 | `ALLOW_LOCAL_SUBNET_TRAFFIC`| `false`           | Set it `true` to allow connections from your local network to the container, WebUI port is still when `false` |
 | `LEGACY_IPTABLES`    | `false`           | Set to `true` if nft protocol not supported or you want to use iptables_legacy            |
 | `DNS_SERVERS`        | `1.1.1.1,1.0.0.1` | DNS servers to use, comma separated [see list](#DNS Servers)          |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ try [WhatisMyIP.net torrent-ip-checker]([http://checkmyip.torrentprivacy.com/](h
 | `PORT_FORWARDING`    | `false`           | Set to `true` if you want to enable port forwarding from PIA, This helps with uploading   |
 | `WEBUI_PORT`         | `8888`            | `1024` to `65535` internal port for HTTP UI                                             |
 | `WEBUI_INTERFACES`   |                   | `eth0` or `eth0,eth1` the interface the WebUI can be accessed through, useful if multiple networks are attached to the container. The default is the interface used for internet access if unset |
-| `OPEN_PORTS`         |                   | A comma-separated list of additional ports (e.g. `1234,5678,9012` you'd like poked into the `WEBUI_INTERFACES` INPUT table in IPTables. Useful for additional containers with WebUIs that need to share the PIA network you're seeding from (e.g. Prowlarr, Mousehole). |
+| `ADDITIONAL_OPEN_PORTS` |                | A comma-separated list of additional ports to open on the local `WEBUI_INTERFACES` (e.g. `1234,5678,9012`). Useful for additional containers with WebUIs that need to share the PIA network you're seeding from (e.g. Prowlarr, Mousehole). |
 | `ALLOW_LOCAL_SUBNET_TRAFFIC`| `false`           | Set it `true` to allow connections from your local network to the container, WebUI port is still when `false` |
 | `LEGACY_IPTABLES`    | `false`           | Set to `true` if nft protocol not supported or you want to use iptables_legacy            |
 | `DNS_SERVERS`        | `1.1.1.1,1.0.0.1` | DNS servers to use, comma separated [see list](#DNS Servers)          |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ try [WhatisMyIP.net torrent-ip-checker]([http://checkmyip.torrentprivacy.com/](h
 | `PORT_FORWARDING`    | `false`           | Set to `true` if you want to enable port forwarding from PIA, This helps with uploading   |
 | `WEBUI_PORT`         | `8888`            | `1024` to `65535` internal port for HTTP UI                                             |
 | `WEBUI_INTERFACES`   |                   | `eth0` or `eth0,eth1` the interface the WebUI can be accessed through, useful if multiple networks are attached to the container. The default is the interface used for internet access if unset |
-| `OPEN_ADDITIONAL_LOCAL_PORTS` |          | A comma-separated list of additional ports to open on the local `WEBUI_INTERFACES` (e.g. `1234,5678,9012`). Useful for additional containers with WebUIs that need to share the PIA network (e.g. Prowlarr, Mousehole). |
+| `OPEN_ADDITIONAL_LOCAL_PORTS` |          | A comma-separated list of additional ports to open on the local WEBUI_INTERFACES (e.g., 1234,5678,9012). Useful for additional containers with WebUIs that share the PIA network via `network_mode: service:pia-qbittorrent` (e.g., Prowlarr, Mousehole). |
 | `ALLOW_LOCAL_SUBNET_TRAFFIC`| `false`           | Set it `true` to allow connections from your local network to the container, WebUI port is still when `false` |
 | `LEGACY_IPTABLES`    | `false`           | Set to `true` if nft protocol not supported or you want to use iptables_legacy            |
 | `DNS_SERVERS`        | `1.1.1.1,1.0.0.1` | DNS servers to use, comma separated [see list](#DNS Servers)          |
@@ -126,6 +126,7 @@ try [WhatisMyIP.net torrent-ip-checker]([http://checkmyip.torrentprivacy.com/](h
 | `CSRFPROTECTION`     |                   | Set to `false` if having trouble accessing the WebUI with unauthorized                            |
 | `DOWNLOAD_DIR`       |                   | Set this to your download folder location. qBittorrent's save and temp paths will update automatically on each start. Leave empty to keep your current settings (default: /downloads) |
 
+Opening additional local ports may leak your internet IP address if the VPN and firewall are not setup before additional containers call the internet, use `condition: service_healthy` in the `depends_on:` section.
 Port forwarding port will be added to qBittorrent settings on startup. A port can last for up to 2 months.  
 To get the user id, run `id -u USER`  
 To get the group id for a user, run `id -g USER`

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ try [WhatisMyIP.net torrent-ip-checker]([http://checkmyip.torrentprivacy.com/](h
 | `PORT_FORWARDING`    | `false`           | Set to `true` if you want to enable port forwarding from PIA, This helps with uploading   |
 | `WEBUI_PORT`         | `8888`            | `1024` to `65535` internal port for HTTP UI                                             |
 | `WEBUI_INTERFACES`   |                   | `eth0` or `eth0,eth1` the interface the WebUI can be accessed through, useful if multiple networks are attached to the container. The default is the interface used for internet access if unset |
+| `OPEN_PORTS`         |                   | A comma-separated list of additional ports (e.g. `1234,5678,9012` you'd like poked into the `WEBUI_INTERFACES` INPUT table in IPTables. Useful for additional containers with WebUIs that need to share the PIA network you're seeding from (e.g. Prowlarr, Mousehole). |
 | `ALLOW_LOCAL_SUBNET_TRAFFIC`| `false`           | Set it `true` to allow connections from your local network to the container, WebUI port is still when `false` |
 | `LEGACY_IPTABLES`    | `false`           | Set to `true` if nft protocol not supported or you want to use iptables_legacy            |
 | `DNS_SERVERS`        | `1.1.1.1,1.0.0.1` | DNS servers to use, comma separated [see list](#DNS Servers)          |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -623,13 +623,13 @@ for webui_interface in  $(echo $WEBUI_INTERFACES | sed "s/,/ /g"); do
   printf "DONE\n"
 done
 
-# Check if ADDITIONAL_OPEN_PORTS is set and not empty
-if [ -n "$ADDITIONAL_OPEN_PORTS" ]; then
+# Check if OPEN_ADDITIONAL_LOCAL_PORTS is set and not empty
+if [ -n "$OPEN_ADDITIONAL_LOCAL_PORTS" ]; then
 # Loop through each WebUI interface
-  printf " * Creating rules for Allowed LAN ports (for other containers):$ADDITIONAL_OPEN_PORTS\n"
+  printf " * Creating rules for Allowed LAN ports (for other containers):$OPEN_ADDITIONAL_LOCAL_PORTS\n"
   for webui_interface in  $(echo $WEBUI_INTERFACES | sed "s/,/ /g"); do
     # Loop through each Open Port in EnvVars, and convert commas to spaces for the loop:
-    for opened_port in  $(echo $ADDITIONAL_OPEN_PORTS | sed "s/,/ /g"); do
+    for opened_port in  $(echo $OPEN_ADDITIONAL_LOCAL_PORTS | sed "s/,/ /g"); do
       # Apply an INPUT rule (allow incoming traffic on WEBUI_Interface for the requested Opened port; Output is not necessary as related/established are already in the rules)
       printf "   * * Opening port $opened_port on interface: $webui_interface..."
       iptables -A INPUT -i "$webui_interface" -p tcp --dport "$opened_port" -j ACCEPT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -623,12 +623,12 @@ for webui_interface in  $(echo $WEBUI_INTERFACES | sed "s/,/ /g"); do
   printf "DONE\n"
 done
 
-printf " * Creating rules for Allowed LAN ports (for other containers):$OPEN_PORTS\n"
-# Check if OPEN_PORTS is set and not empty
-if [ -n "$OPEN_PORTS" ]; then
+printf " * Creating rules for Allowed LAN ports (for other containers):$ADDITIONAL_OPEN_PORTS\n"
+# Check if ADDITIONAL_OPEN_PORTS is set and not empty
+if [ -n "$ADDITIONAL_OPEN_PORTS" ]; then
 	# Loop through each Open Port in EnvVars, and convert commas to spaces for the loop:
-	for opened_port in  $(echo $OPEN_PORTS | sed "s/,/ /g"); do
-  		# Apply an INPUT rule (allow incoming traffic on WEBUI_PORT for the requested Opened port; Output is not necessary as related/established are already in the rules)
+	for opened_port in  $(echo $ADDITIONAL_OPEN_PORTS | sed "s/,/ /g"); do
+  		# Apply an INPUT rule (allow incoming traffic on WEBUI_Interface for the requested Opened port; Output is not necessary as related/established are already in the rules)
   		printf "   * * Opened port $opened_port on interface: $webui_interface..."
   		iptables -A INPUT -i "$webui_interface" -p tcp --dport "$opened_port" -j ACCEPT
   		printf "DONE\n"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -623,16 +623,19 @@ for webui_interface in  $(echo $WEBUI_INTERFACES | sed "s/,/ /g"); do
   printf "DONE\n"
 done
 
-printf " * Creating rules for Allowed LAN ports (for other containers):$ADDITIONAL_OPEN_PORTS\n"
 # Check if ADDITIONAL_OPEN_PORTS is set and not empty
 if [ -n "$ADDITIONAL_OPEN_PORTS" ]; then
-	# Loop through each Open Port in EnvVars, and convert commas to spaces for the loop:
-	for opened_port in  $(echo $ADDITIONAL_OPEN_PORTS | sed "s/,/ /g"); do
-  		# Apply an INPUT rule (allow incoming traffic on WEBUI_Interface for the requested Opened port; Output is not necessary as related/established are already in the rules)
-  		printf "   * * Opened port $opened_port on interface: $webui_interface..."
-  		iptables -A INPUT -i "$webui_interface" -p tcp --dport "$opened_port" -j ACCEPT
-  		printf "DONE\n"
-	done
+# Loop through each WebUI interface
+  printf " * Creating rules for Allowed LAN ports (for other containers):$ADDITIONAL_OPEN_PORTS\n"
+  for webui_interface in  $(echo $WEBUI_INTERFACES | sed "s/,/ /g"); do
+    # Loop through each Open Port in EnvVars, and convert commas to spaces for the loop:
+    for opened_port in  $(echo $ADDITIONAL_OPEN_PORTS | sed "s/,/ /g"); do
+      # Apply an INPUT rule (allow incoming traffic on WEBUI_Interface for the requested Opened port; Output is not necessary as related/established are already in the rules)
+      printf "   * * Opening port $opened_port on interface: $webui_interface..."
+      iptables -A INPUT -i "$webui_interface" -p tcp --dport "$opened_port" -j ACCEPT
+      printf "DONE\n"
+    done
+  done
 fi
 
 printf " * Creating VPN routes..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -217,6 +217,9 @@ printf " * Region: $server\n"
 printf " * VPN Client: $VPN_CLIENT\n"
 printf "Local network parameters:\n"
 printf " * Web UI port: $WEBUI_PORT\n"
+if [ -n "$OPEN_PORTS" ]; then
+	printf " * Requested opened firewall ports: $OPEN_PORTS\n"
+fi
 printf " * Adding PIA DNS Servers\n"
 cat /dev/null > /etc/resolv.conf
 for name_server in $(echo $DNS_SERVERS | sed "s/,/ /g")
@@ -619,6 +622,18 @@ for webui_interface in  $(echo $WEBUI_INTERFACES | sed "s/,/ /g"); do
   iptables -A INPUT -i "$webui_interface" -p tcp --sport "$WEBUI_PORT" -j ACCEPT
   printf "DONE\n"
 done
+
+printf " * Creating rules for Allowed LAN ports (for other containers):$OPEN_PORTS\n"
+# Check if OPEN_PORTS is set and not empty
+if [ -n "$OPEN_PORTS" ]; then
+	# Loop through each Open Port in EnvVars, and convert commas to spaces for the loop:
+	for opened_port in  $(echo $OPEN_PORTS | sed "s/,/ /g"); do
+  		# Apply an INPUT rule (allow incoming traffic on WEBUI_PORT for the requested Opened port; Output is not necessary as related/established are already in the rules)
+  		printf "   * * Opened port $opened_port on interface: $webui_interface..."
+  		iptables -A INPUT -i "$webui_interface" -p tcp --dport "$opened_port" -j ACCEPT
+  		printf "DONE\n"
+	done
+fi
 
 printf " * Creating VPN routes..."
 ip rule add from $(ip route get 1 | ack -o '(?<=src )(\S+)') table 128


### PR DESCRIPTION
This PR tweaks the entrypoint.sh file to add monitoring/logging for a new EnvVar: `OPEN_PORTS`, which will add additional ports opened to the WebUI Interface, Input table in IPTables. This is useful for other containers like Prowlarr and Mousehole, which should share the public IP Address of the torrent client for updating Private Tracker allowed IPs. This only opens the Input rule for the comma-separated list of ports, and not the corresponding output rule (that's covered for WebUIs under Related/Established), so this shouldn't result in any data leaks. Tested in my environment.